### PR TITLE
Automatically set access_token_ upon successful login

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -224,7 +224,15 @@ Client::login(
         req.user     = user;
         req.password = password;
 
-        post<mtx::requests::Login, mtx::responses::Login>("/login", req, callback, false);
+        post<mtx::requests::Login, mtx::responses::Login>("/login", req, [this,callback](const mtx::responses::Login &resp,
+                     std::experimental::optional<mtx::client::errors::ClientError> err ) {
+				if(!err && resp.access_token.size()) {
+					access_token_ = resp.access_token;
+				}
+				callback(resp,err);
+			},
+		       	false);
+
 }
 
 void

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -224,15 +224,17 @@ Client::login(
         req.user     = user;
         req.password = password;
 
-        post<mtx::requests::Login, mtx::responses::Login>("/login", req, [this,callback](const mtx::responses::Login &resp,
-                     std::experimental::optional<mtx::client::errors::ClientError> err ) {
-				if(!err && resp.access_token.size()) {
-					access_token_ = resp.access_token;
-				}
-				callback(resp,err);
-			},
-		       	false);
-
+        post<mtx::requests::Login, mtx::responses::Login>(
+          "/login",
+          req,
+          [this, callback](const mtx::responses::Login &resp,
+                           std::experimental::optional<mtx::client::errors::ClientError> err) {
+                  if (!err && resp.access_token.size()) {
+                          access_token_ = resp.access_token;
+                  }
+                  callback(resp, err);
+          },
+          false);
 }
 
 void

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -6,10 +6,10 @@
 std::string
 mtx::client::utils::random_token(uint8_t len)
 {
-        std ::string chars("abcdefghijklmnopqrstuvwxyz"
-                           "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-                           "1234567890"
-                           "!@#$%^&*()");
+        std::string chars("abcdefghijklmnopqrstuvwxyz"
+                          "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                          "1234567890"
+                          "!@#$%^&*()");
         boost::random::random_device rng;
         boost::random::uniform_int_distribution<> index_dist(0, chars.size() - 1);
 

--- a/tests/client_api.cpp
+++ b/tests/client_api.cpp
@@ -114,17 +114,17 @@ TEST(ClientAPI, CreateRoomInvites)
         auto carl  = std::make_shared<Client>("localhost");
 
         alice->login("alice", "secret", [alice](const mtx::responses::Login &res, ErrType err) {
-		boost::ignore_unused(res);
+                boost::ignore_unused(res);
                 ASSERT_FALSE(err);
         });
 
         bob->login("bob", "secret", [bob](const mtx::responses::Login &res, ErrType err) {
-		boost::ignore_unused(res);
+                boost::ignore_unused(res);
                 ASSERT_FALSE(err);
         });
 
         carl->login("carl", "secret", [carl](const mtx::responses::Login &res, ErrType err) {
-		boost::ignore_unused(res);
+                boost::ignore_unused(res);
                 ASSERT_FALSE(err);
         });
 
@@ -157,12 +157,12 @@ TEST(ClientAPI, JoinRoom)
         auto bob   = std::make_shared<Client>("localhost");
 
         alice->login("alice", "secret", [alice](const mtx::responses::Login &res, ErrType err) {
-		boost::ignore_unused(res);
+                boost::ignore_unused(res);
                 ASSERT_FALSE(err);
         });
 
         bob->login("bob", "secret", [bob](const mtx::responses::Login &res, ErrType err) {
-		boost::ignore_unused(res);
+                boost::ignore_unused(res);
                 ASSERT_FALSE(err);
         });
 
@@ -200,12 +200,12 @@ TEST(ClientAPI, LeaveRoom)
         auto bob   = std::make_shared<Client>("localhost");
 
         alice->login("alice", "secret", [alice](const mtx::responses::Login &res, ErrType err) {
-		boost::ignore_unused(res);
+                boost::ignore_unused(res);
                 ASSERT_FALSE(err);
         });
 
         bob->login("bob", "secret", [bob](const mtx::responses::Login &res, ErrType err) {
-		boost::ignore_unused(res);
+                boost::ignore_unused(res);
                 ASSERT_FALSE(err);
         });
 
@@ -246,8 +246,8 @@ TEST(ClientAPI, Sync)
 
         mtx_client->login(
           "alice", "secret", [mtx_client](const mtx::responses::Login &res, ErrType err) {
-		boost::ignore_unused(res);
-		ASSERT_FALSE(err);
+                  boost::ignore_unused(res);
+                  ASSERT_FALSE(err);
           });
 
         // Waiting for the previous request to complete.

--- a/tests/client_api.cpp
+++ b/tests/client_api.cpp
@@ -90,8 +90,6 @@ TEST(ClientAPI, CreateRoom)
           "alice", "secret", [mtx_client](const mtx::responses::Login &res, ErrType err) {
                   ASSERT_FALSE(err);
                   validate_login("@alice:localhost", res);
-
-                  mtx_client->set_access_token(res.access_token);
           });
 
         // Waiting for the previous request to complete.
@@ -116,18 +114,18 @@ TEST(ClientAPI, CreateRoomInvites)
         auto carl  = std::make_shared<Client>("localhost");
 
         alice->login("alice", "secret", [alice](const mtx::responses::Login &res, ErrType err) {
+		boost::ignore_unused(res);
                 ASSERT_FALSE(err);
-                alice->set_access_token(res.access_token);
         });
 
         bob->login("bob", "secret", [bob](const mtx::responses::Login &res, ErrType err) {
+		boost::ignore_unused(res);
                 ASSERT_FALSE(err);
-                bob->set_access_token(res.access_token);
         });
 
         carl->login("carl", "secret", [carl](const mtx::responses::Login &res, ErrType err) {
+		boost::ignore_unused(res);
                 ASSERT_FALSE(err);
-                carl->set_access_token(res.access_token);
         });
 
         // Waiting for the previous requests to complete.
@@ -159,13 +157,13 @@ TEST(ClientAPI, JoinRoom)
         auto bob   = std::make_shared<Client>("localhost");
 
         alice->login("alice", "secret", [alice](const mtx::responses::Login &res, ErrType err) {
+		boost::ignore_unused(res);
                 ASSERT_FALSE(err);
-                alice->set_access_token(res.access_token);
         });
 
         bob->login("bob", "secret", [bob](const mtx::responses::Login &res, ErrType err) {
+		boost::ignore_unused(res);
                 ASSERT_FALSE(err);
-                bob->set_access_token(res.access_token);
         });
 
         // Waiting for the previous requests to complete.
@@ -202,13 +200,13 @@ TEST(ClientAPI, LeaveRoom)
         auto bob   = std::make_shared<Client>("localhost");
 
         alice->login("alice", "secret", [alice](const mtx::responses::Login &res, ErrType err) {
+		boost::ignore_unused(res);
                 ASSERT_FALSE(err);
-                alice->set_access_token(res.access_token);
         });
 
         bob->login("bob", "secret", [bob](const mtx::responses::Login &res, ErrType err) {
+		boost::ignore_unused(res);
                 ASSERT_FALSE(err);
-                bob->set_access_token(res.access_token);
         });
 
         // Waiting for the previous requests to complete.
@@ -248,8 +246,8 @@ TEST(ClientAPI, Sync)
 
         mtx_client->login(
           "alice", "secret", [mtx_client](const mtx::responses::Login &res, ErrType err) {
-                  ASSERT_FALSE(err);
-                  mtx_client->set_access_token(res.access_token);
+		boost::ignore_unused(res);
+		ASSERT_FALSE(err);
           });
 
         // Waiting for the previous request to complete.


### PR DESCRIPTION
I wrapped the login-supplied callback with another callback who's purpose is to set the Client's access_token_ if there is no error and if an access_token is present in the Login response before calling the callback with the response and error.

This will make interfacing with the Client easier.

