### PR TITLE
Added a set_displayname and put function

### DIFF
--- a/cmake/MatrixStructs.cmake
+++ b/cmake/MatrixStructs.cmake
@@ -12,8 +12,8 @@ set(MATRIX_STRUCTS_INCLUDE_DIRS ${MATRIX_STRUCTS_ROOT}/deps)
 ExternalProject_Add(
   MatrixStructs
 
-  GIT_REPOSITORY https://github.com/ajberchek/matrix-structs
-  GIT_TAG f3fdd6e0798d90140d2be37503fd6293c634b293
+  GIT_REPOSITORY https://github.com/mujx/matrix-structs
+  GIT_TAG da342f3b3ccf4f505459697f3d857274d0704c45
 
   BUILD_IN_SOURCE 1
   SOURCE_DIR ${MATRIX_STRUCTS_ROOT}

--- a/cmake/MatrixStructs.cmake
+++ b/cmake/MatrixStructs.cmake
@@ -12,8 +12,8 @@ set(MATRIX_STRUCTS_INCLUDE_DIRS ${MATRIX_STRUCTS_ROOT}/deps)
 ExternalProject_Add(
   MatrixStructs
 
-  GIT_REPOSITORY https://github.com/mujx/matrix-structs
-  GIT_TAG 83be1388e632a43f0570857cb79313c09fb3da0b
+  GIT_REPOSITORY https://github.com/ajberchek/matrix-structs
+  GIT_TAG f3fdd6e0798d90140d2be37503fd6293c634b293
 
   BUILD_IN_SOURCE 1
   SOURCE_DIR ${MATRIX_STRUCTS_ROOT}

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -230,6 +230,7 @@ Client::login(
           [this, callback](const mtx::responses::Login &resp,
                            std::experimental::optional<mtx::client::errors::ClientError> err) {
                   if (!err && resp.access_token.size()) {
+                          user_id_      = resp.user_id;
                           access_token_ = resp.access_token;
                   }
                   callback(resp, err);
@@ -265,7 +266,8 @@ Client::set_displayname(
         mtx::requests::DisplayName req;
         req.displayname = displayname;
 
-        put<mtx::requests::Login, mtx::responses::Login>("/profile/" + user_id_.toString() + "/displayname",req,callback);
+        put<mtx::requests::Login, mtx::responses::Login>(
+          "/profile/" + user_id_.toString() + "/displayname", req, callback);
 }
 
 void

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -258,6 +258,8 @@ Client::logout(
                   callback(res, err);
           });
 }
+
+void
 Client::set_displayname(
   const std::string &displayname,
   std::function<void(std::experimental::optional<mtx::client::errors::ClientError>)> callback)

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -257,6 +257,16 @@ Client::logout(
                   callback(res, err);
           });
 }
+Client::set_displayname(
+  const std::string &displayname,
+  std::function<void(const mtx::responses::DisplayName &response,
+                     std::experimental::optional<mtx::client::errors::ClientError>)> callback)
+{
+        mtx::requests::DisplayName req;
+        req.displayname = displayname;
+
+        put<mtx::requests::Login, mtx::responses::Login>("/profile/" + user_id_.toString() + "/displayname",req,callback);
+}
 
 void
 Client::create_room(const mtx::requests::CreateRoom &room_options,

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -260,13 +260,12 @@ Client::logout(
 }
 Client::set_displayname(
   const std::string &displayname,
-  std::function<void(const mtx::responses::DisplayName &response,
-                     std::experimental::optional<mtx::client::errors::ClientError>)> callback)
+  std::function<void(std::experimental::optional<mtx::client::errors::ClientError>)> callback)
 {
         mtx::requests::DisplayName req;
         req.displayname = displayname;
 
-        put<mtx::requests::Login, mtx::responses::Login>(
+        put<mtx::requests::DisplayName>(
           "/profile/" + user_id_.toString() + "/displayname", req, callback);
 }
 

--- a/src/client.hpp
+++ b/src/client.hpp
@@ -49,6 +49,9 @@ public:
                    std::function<void(const mtx::responses::Login &response, RequestErr err)>);
         //! Perform logout.
         void logout(std::function<void(const mtx::responses::Logout &response, RequestErr err)>);
+        //! Change displayname.
+        void set_displayname(const std::string &displayname,
+                   std::function<void(const mtx::responses::DisplayName &response, RequestErr err)>);
         //! Create a room with the given options.
         void create_room(
           const mtx::requests::CreateRoom &room_options,
@@ -140,6 +143,8 @@ private:
         std::string server_;
         //! The access token that would be used for authentication.
         std::string access_token_;
+	//! The user ID associated with the client.
+        std::string user_id_;
         //! The token that will be used as the 'since' parameter on the next sync request.
         std::string next_batch_token_;
 };

--- a/src/client.hpp
+++ b/src/client.hpp
@@ -105,6 +105,12 @@ private:
                              std::experimental::optional<mtx::client::errors::ClientError>)>,
           bool requires_auth = true);
 
+        template<class Request>
+        void put(const std::string &endpoint,
+                 const Request &req,
+                 std::function<void(std::experimental::optional<mtx::client::errors::ClientError>)>,
+                 bool requires_auth = true);
+
         template<class Response>
         void get(const std::string &endpoint,
                  std::function<void(const Response &,
@@ -170,6 +176,36 @@ mtx::client::Client::post(
         std::shared_ptr<Session> session = create_session<Response, CallbackType>(callback);
 
         session->request.method(boost::beast::http::verb::post);
+        session->request.target("/_matrix/client/r0" + endpoint);
+        session->request.set(boost::beast::http::field::user_agent, "mtxclient v0.1.0");
+        session->request.set(boost::beast::http::field::content_type, "application/json");
+        session->request.set(boost::beast::http::field::host, session->host);
+        if (requires_auth && !access_token_.empty())
+                session->request.set(boost::beast::http::field::authorization,
+                                     "Bearer " + access_token_);
+        session->request.body() = j.dump();
+        session->request.prepare_payload();
+
+        do_request(session);
+}
+
+template<class Request>
+void
+mtx::client::Client::put(
+  const std::string &endpoint,
+  const Request &req,
+  std::function<void(std::experimental::optional<mtx::client::errors::ClientError>)> callback,
+  bool requires_auth)
+{
+        // Serialize request.
+        nlohmann::json j = req;
+
+        using CallbackType =
+          std::function<void(std::experimental::optional<mtx::client::errors::ClientError>)>;
+
+        std::shared_ptr<Session> session = create_session<CallbackType>(callback);
+
+        session->request.method(boost::beast::http::verb::put);
         session->request.target("/_matrix/client/r0" + endpoint);
         session->request.set(boost::beast::http::field::user_agent, "mtxclient v0.1.0");
         session->request.set(boost::beast::http::field::content_type, "application/json");

--- a/src/client.hpp
+++ b/src/client.hpp
@@ -50,8 +50,9 @@ public:
         //! Perform logout.
         void logout(std::function<void(const mtx::responses::Logout &response, RequestErr err)>);
         //! Change displayname.
-        void set_displayname(const std::string &displayname,
-                   std::function<void(const mtx::responses::DisplayName &response, RequestErr err)>);
+        void set_displayname(
+          const std::string &displayname,
+          std::function<void(const mtx::responses::DisplayName &response, RequestErr err)>);
         //! Create a room with the given options.
         void create_room(
           const mtx::requests::CreateRoom &room_options,
@@ -143,7 +144,7 @@ private:
         std::string server_;
         //! The access token that would be used for authentication.
         std::string access_token_;
-	//! The user ID associated with the client.
+        //! The user ID associated with the client.
         std::string user_id_;
         //! The token that will be used as the 'since' parameter on the next sync request.
         std::string next_batch_token_;

--- a/src/client.hpp
+++ b/src/client.hpp
@@ -239,27 +239,14 @@ mtx::client::Client::put(
         // Serialize request.
         nlohmann::json j = req;
 
-        using CallbackType = std::function<void(
-          mtx::responses::Empty, std::experimental::optional<mtx::client::errors::ClientError>)>;
-
-        std::shared_ptr<Session> session = create_session<mtx::responses::Empty, CallbackType>(
+        mtx::client::Client::put<Request, mtx::responses::Empty>(
+          endpoint,
+          req,
           [callback](const mtx::responses::Empty,
                      std::experimental::optional<mtx::client::errors::ClientError> err) {
                   callback(err);
-          });
-
-        session->request.method(boost::beast::http::verb::put);
-        session->request.target("/_matrix/client/r0" + endpoint);
-        session->request.set(boost::beast::http::field::user_agent, "mtxclient v0.1.0");
-        session->request.set(boost::beast::http::field::content_type, "application/json");
-        session->request.set(boost::beast::http::field::host, session->host);
-        if (requires_auth && !access_token_.empty())
-                session->request.set(boost::beast::http::field::authorization,
-                                     "Bearer " + access_token_);
-        session->request.body() = j.dump();
-        session->request.prepare_payload();
-
-        do_request(session);
+          },
+          requires_auth);
 }
 
 template<class Response>

--- a/src/client.hpp
+++ b/src/client.hpp
@@ -103,6 +103,14 @@ private:
                              std::experimental::optional<mtx::client::errors::ClientError>)>,
           bool requires_auth = true);
 
+        // put function for the PUT HTTP requests that send responses
+        template<class Request, class Response>
+        void put(const std::string &endpoint,
+                 const Request &req,
+                 std::function<void(const Response &,
+                                    std::experimental::optional<mtx::client::errors::ClientError>)>,
+                 bool requires_auth = true);
+
         template<class Request>
         void put(const std::string &endpoint,
                  const Request &req,
@@ -187,6 +195,39 @@ mtx::client::Client::post(
         do_request(session);
 }
 
+// put function for the PUT HTTP requests that send responses
+template<class Request, class Response>
+void
+mtx::client::Client::put(
+  const std::string &endpoint,
+  const Request &req,
+  std::function<void(const Response &,
+                     std::experimental::optional<mtx::client::errors::ClientError>)> callback,
+  bool requires_auth)
+{
+        // Serialize request.
+        nlohmann::json j = req;
+
+        using CallbackType = std::function<void(
+          const Response &, std::experimental::optional<mtx::client::errors::ClientError>)>;
+
+        std::shared_ptr<Session> session = create_session<Response, CallbackType>(callback);
+
+        session->request.method(boost::beast::http::verb::put);
+        session->request.target("/_matrix/client/r0" + endpoint);
+        session->request.set(boost::beast::http::field::user_agent, "mtxclient v0.1.0");
+        session->request.set(boost::beast::http::field::content_type, "application/json");
+        session->request.set(boost::beast::http::field::host, session->host);
+        if (requires_auth && !access_token_.empty())
+                session->request.set(boost::beast::http::field::authorization,
+                                     "Bearer " + access_token_);
+        session->request.body() = j.dump();
+        session->request.prepare_payload();
+
+        do_request(session);
+}
+
+// provides PUT functionality for the endpoints which dont respond with a body
 template<class Request>
 void
 mtx::client::Client::put(

--- a/src/client.hpp
+++ b/src/client.hpp
@@ -192,7 +192,7 @@ void
 mtx::client::Client::put(
   const std::string &endpoint,
   const Request &req,
-  std::function<void(std::experimental::optional<mtx::client::errors::ClientError>)> call,
+  std::function<void(std::experimental::optional<mtx::client::errors::ClientError>)> callback,
   bool requires_auth)
 {
         // Serialize request.
@@ -202,8 +202,10 @@ mtx::client::Client::put(
           mtx::responses::Empty, std::experimental::optional<mtx::client::errors::ClientError>)>;
 
         std::shared_ptr<Session> session = create_session<mtx::responses::Empty, CallbackType>(
-          [call](const mtx::responses::Empty,
-                 std::experimental::optional<mtx::client::errors::ClientError> err) { call(err); });
+          [callback](const mtx::responses::Empty,
+                     std::experimental::optional<mtx::client::errors::ClientError> err) {
+                  callback(err);
+          });
 
         session->request.method(boost::beast::http::verb::put);
         session->request.target("/_matrix/client/r0" + endpoint);

--- a/tests/client_api.cpp
+++ b/tests/client_api.cpp
@@ -111,12 +111,7 @@ TEST(ClientAPI, EmptyDisplayName)
 
                   // Change the display name to an empty string and verify its success through the
                   // lack of an error
-                  mtx_client->set_displayname("", [](ErrType err) {
-                          std::cout << mtx::errors::to_string(err->matrix_error.errcode)
-                                    << std::endl;
-
-                          ASSERT_FALSE(err);
-                  });
+                  mtx_client->set_displayname("", [](ErrType err) { ASSERT_FALSE(err); });
           });
 
         mtx_client->close();

--- a/tests/client_api.cpp
+++ b/tests/client_api.cpp
@@ -82,6 +82,24 @@ TEST(ClientAPI, LoginWrongUsername)
         mtx_client->close();
 }
 
+TEST(ClientAPI, ChangeDisplayName)
+{
+        std::shared_ptr<Client> mtx_client = std::make_shared<Client>("localhost");
+
+        mtx_client->login(
+          "alice", "secret", [mtx_client](const mtx::responses::Login &res, ErrType err) {
+                  ASSERT_FALSE(err);
+                  validate_login("@alice:localhost", res);
+
+                  // Change the display name to Arthur Dent and verify its success through the lack
+                  // of an error
+                  mtx_client->set_displayname("Arthur Dent",
+                                              [](ErrType err) { ASSERT_FALSE(err); });
+          });
+
+        mtx_client->close();
+}
+
 TEST(ClientAPI, CreateRoom)
 {
         std::shared_ptr<Client> mtx_client = std::make_shared<Client>("localhost");

--- a/tests/client_api.cpp
+++ b/tests/client_api.cpp
@@ -100,6 +100,28 @@ TEST(ClientAPI, ChangeDisplayName)
         mtx_client->close();
 }
 
+TEST(ClientAPI, EmptyDisplayName)
+{
+        std::shared_ptr<Client> mtx_client = std::make_shared<Client>("localhost");
+
+        mtx_client->login(
+          "alice", "secret", [mtx_client](const mtx::responses::Login &res, ErrType err) {
+                  ASSERT_FALSE(err);
+                  validate_login("@alice:localhost", res);
+
+                  // Change the display name to an empty string and verify its success through the
+                  // lack of an error
+                  mtx_client->set_displayname("", [](ErrType err) {
+                          std::cout << mtx::errors::to_string(err->matrix_error.errcode)
+                                    << std::endl;
+
+                          ASSERT_FALSE(err);
+                  });
+          });
+
+        mtx_client->close();
+}
+
 TEST(ClientAPI, CreateRoom)
 {
         std::shared_ptr<Client> mtx_client = std::make_shared<Client>("localhost");


### PR DESCRIPTION
Added functionality to allow a user to change their display name per issue #12 

I also created a PUT function that takes a callback who's only parameter is an error since no response body is returned from a PUT request upon a successful request.

This depends on the functionality in matrix-structs PR 6, so I pointed the submodule to my fork in that PR.